### PR TITLE
Use new fields instead of regex

### DIFF
--- a/copy-db.sh
+++ b/copy-db.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "use cranlike\ndb.dropDatabase()" | mongosh
-for user in ropensci bioc jeroen; do
+for user in ropensci jeroen; do
   echo "Copying data for $user"
   curl -L "https://$user.r-universe.dev/api/dbdump?everything=1" -o $user.bson
   mongorestore -d cranlike -c packages $user.bson

--- a/run-local.sh
+++ b/run-local.sh
@@ -5,6 +5,6 @@ else
 mongoconfig="/usr/local/etc/mongod.conf"
 fi
 export NODE_ENV=production
-export UNIVERSE=bioc
+export UNIVERSE=ropensci
 DEBUG=cranlike:* mongod --config $mongoconfig & sleep 2 & npm start
 

--- a/src/tools.js
+++ b/src/tools.js
@@ -165,16 +165,6 @@ export function doc_to_dcf(doc){
   }).join("\n") + "\n\n";
 }
 
-export function match_macos_arch(platform){
-  if(platform.match("arm64|aarch64")){
-    return {$not : /x86_64/};
-  }
-  if(platform.match("x86_64")){
-    return {$not : /aarch64/};
-  }
-  throw createError(404, `Unsupported MacOS version: ${platform}`);
-}
-
 export function doc_to_paths(doc){
   var type = doc._type;
   if(type == 'src'){


### PR DESCRIPTION
Preparations for arm64 support. We now keep `_arch` and `_major` fields in the db such that we don't need to use regexes to find compatible binaries.