### PR TITLE
Fix small typo in tour description of downloads button

### DIFF
--- a/views/pkginfo.pug
+++ b/views/pkginfo.pug
@@ -213,7 +213,7 @@ block content
             i.fa-solid.fa-code
             |  #{format_count(_searchresults)} scripts
         if _downloads && _downloads.count > 0
-          a.text-muted.badge.text-bg-light.p-1.me-1.border(target='_blank' href=_downloads.source data-title="Download statistics" data-intro="Montly downloads on CRAN and BioConductor.")
+          a.text-muted.badge.text-bg-light.p-1.me-1.border(target='_blank' href=_downloads.source data-title="Download statistics" data-intro="Monthly downloads on CRAN and BioConductor.")
             i.fas.fa-download.text-success-emphasis
             |  #{format_count(_downloads.count)} downloads
         if _mentions


### PR DESCRIPTION
I saw the exciting news about the new [collaboration between r-universe and Bioconductor](https://ropensci.org/blog/2026/04/08/r-universe-bioc/). Thanks for this amazing work to improve the R ecosystem!

While taking the interactive tour I noticed a minor typo. This PR fixes it.

https://github.com/r-universe-org/frontend/blob/c4249a52f1d0eb9e61976c4d64936d3617fdebf6/views/pkginfo.pug#L216