### PR TITLE
Bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - id: prep
         name: find version
@@ -22,13 +22,13 @@ jobs:
           echo "date=$(date +"%Y%m%d")" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR (GitHub Packages)
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: |


### PR DESCRIPTION
## Summary
- Updates third-party GitHub Actions in `.github/workflows/` to their latest major versions.

| Action | Before | After |
| --- | --- | --- |
| actions/checkout | v4 | v7 |
| docker/login-action | v3 | v4 |
| docker/build-push-action | v5 | v7 |
| docker/setup-buildx-action | v3 | v4 |
| docker/setup-qemu-action | v3 | v4 |

## Test plan
- [ ] Trigger the affected workflow(s) and confirm they still run.