### PR TITLE
Do not exit on uncaught undici socket errors

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -7,7 +7,14 @@ import app from '../app.js';
    We quit because in a case of OOM/DOS, a restart may just be the best solution.
    See: https://github.com/r-universe-org/help/issues/310 */
 process.on('uncaughtException', function(err) {
-  console.log( "[UNCAUGHT EXCEPTION] " + err.stack || err.message );
+  /* Undici h2 teardown races can emit socket errors that cannot be caught
+     in userland. A dead pooled connection does not corrupt process state,
+     so log and keep serving instead of restarting the container. */
+  if (err.code === 'UND_ERR_SOCKET') {
+    console.log("[IGNORED SOCKET ERROR] " + (err.stack || err.message));
+    return;
+  }
+  console.log("[UNCAUGHT EXCEPTION] " + (err.stack || err.message));
   process.exit(1);
 });
 


### PR DESCRIPTION
Workaround for https://github.com/nodejs/undici/issues/5525

Undici 8 negotiates HTTP/2 by default, and its h2 client has teardown races where a `SocketError` is emitted on an internal socket/session/stream that no longer has an error listener (e.g. when the server closes a pooled connection around GOAWAY/idle-close). These errors cannot be caught at the request site — they bypass the request promise and `pipeline()` entirely and land on `process.on('uncaughtException')`, where our last-resort handler calls `process.exit(1)` and restarts the container.

